### PR TITLE
납부 업무 노션·텔레그램 연동 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.env
+.env.*
+age.key
+k8s/

--- a/.github/workflows/bootstrap-sops-secret.yml
+++ b/.github/workflows/bootstrap-sops-secret.yml
@@ -1,0 +1,56 @@
+name: SOPS 비밀값 최초 변환
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  migrate-env-vars:
+    runs-on: ubuntu-latest
+    environment: Production
+
+    steps:
+      - name: 저장소 가져오기
+        uses: actions/checkout@v4
+
+      - name: SOPS 설치
+        uses: getsops/action@v2
+
+      - name: 기존 ENV_VARS를 암호화된 Kubernetes Secret으로 변환
+        env:
+          ENV_VARS: ${{ secrets.ENV_VARS }}
+        run: |
+          test -n "$ENV_VARS" || { echo "ENV_VARS 시크릿이 비어 있습니다."; exit 1; }
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          values = {}
+          for raw_line in os.environ["ENV_VARS"].splitlines():
+              line = raw_line.strip()
+              if not line or line.startswith("#"):
+                  continue
+              key, separator, value = raw_line.partition("=")
+              if not separator or not key.strip():
+                  raise ValueError(f"올바르지 않은 환경변수 줄입니다: {raw_line!r}")
+              values[key.strip()] = value
+
+          secret_file = Path("k8s/dup-env.sops.yaml")
+          secret_file.parent.mkdir(exist_ok=True)
+          with secret_file.open("w", encoding="utf-8") as file:
+              file.write("apiVersion: v1\nkind: Secret\nmetadata:\n  name: dup-env\ntype: Opaque\nstringData:\n")
+              for key, value in sorted(values.items()):
+                  file.write(f"  {json.dumps(key, ensure_ascii=False)}: {json.dumps(value, ensure_ascii=False)}\n")
+          PY
+          sops --encrypt --in-place k8s/dup-env.sops.yaml
+
+      - name: 암호화 파일 커밋
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add k8s/dup-env.sops.yaml
+          git diff --cached --quiet || git commit -m "운영 환경 비밀값 암호화"
+          git push

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main # `main` 브랜치에 push 될 때 실행
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,15 +12,53 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # 1️⃣ .env 파일 생성 (Docker Build 전에 필요)
-      - name: Create .env file
+      # SOPS 파일이 준비되기 전 첫 배포만 기존 ENV_VARS를 사용한다.
+      # 변환이 끝나면 ENV_VARS를 삭제해도 된다.
+      - name: SOPS 설치
+        uses: getsops/action@v2
+
+      - name: Kubernetes Secret 준비
+        env:
+          ENV_VARS: ${{ secrets.ENV_VARS }}
+          SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
         run: |
-          echo "🔐 .env 파일 생성 중..."
-          echo -e "${{ secrets.ENV_VARS }}" > .env  # `.env` 생성
-          chmod 600 .env
-          echo "✅ .env 파일 생성 완료!"
+          if [ -f k8s/dup-env.sops.yaml ]; then
+            test -n "$SOPS_AGE_KEY" || { echo "SOPS_AGE_KEY 시크릿이 비어 있습니다."; exit 1; }
+            sops --decrypt k8s/dup-env.sops.yaml > k8s/dup-env.yaml
+          else
+            test -n "$ENV_VARS" || { echo "ENV_VARS 시크릿이 비어 있습니다."; exit 1; }
+            python3 - <<'PY'
+            import json
+            import os
+            from pathlib import Path
+
+            values = {}
+            for raw_line in os.environ["ENV_VARS"].splitlines():
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                key, separator, value = raw_line.partition("=")
+                if not separator or not key.strip():
+                    raise ValueError(f"올바르지 않은 환경변수 줄입니다: {raw_line!r}")
+                values[key.strip()] = value
+
+            with Path("k8s/dup-env.yaml").open("w", encoding="utf-8") as file:
+                file.write("apiVersion: v1\nkind: Secret\nmetadata:\n  name: dup-env\ntype: Opaque\nstringData:\n")
+                for key, value in sorted(values.items()):
+                    file.write(f"  {json.dumps(key, ensure_ascii=False)}: {json.dumps(value, ensure_ascii=False)}\n")
+            PY
+
+      - name: Kubernetes Secret 전달
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          source: k8s/dup-env.yaml
+          target: /tmp
 
       # 2️⃣ Docker 로그인 (GitHub 또는 Docker Hub)
       - name: Log in to Docker Hub
@@ -38,7 +76,7 @@ jobs:
           docker push $IMAGE_NAME:$TAG
           echo "IMAGE_TAG=$TAG" >> $GITHUB_ENV
 
-      # 4️⃣ K3s 서버에 SSH 접속하여 배포 업데이트
+      # K3s에는 Secret만 전달하고, Docker 이미지는 코드만 담는다.
       - name: Deploy to K3s
         uses: appleboy/ssh-action@master
         with:
@@ -47,6 +85,8 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            echo "🔐 K3s 서버에서 배포 재시작..."
+            kubectl apply -f /tmp/k8s/dup-env.yaml
+            rm -rf /tmp/k8s
+            kubectl set env deployment/dup --from=secret/dup-env
             kubectl rollout restart deployment/dup
             echo "✅ 배포 완료!"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ __pycache__/
 *.pyd
 .env
 .env.*
+age.key
+k8s/dup-env.yaml
 
 # venv
 venv/

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,3 @@
+creation_rules:
+  - path_regex: k8s/dup-env\.sops\.yaml$
+    age: age1n5jf6c3qn6wgsr8sjw9f3cmd62u599qgsqffkksuxmkfemrfxafqykdp48

--- a/README.md
+++ b/README.md
@@ -110,9 +110,68 @@ PAYMENT_SUMMARY_MINUTE=30
 
 운영 비밀값은 `.env` 파일을 Docker 이미지에 포함하지 않고, 암호화된 `k8s/dup-env.sops.yaml` 파일에서 Kubernetes Secret으로 배포합니다.
 
-최초 1회에는 GitHub `Production` 환경 시크릿에 `SOPS_AGE_KEY`를 등록한 뒤, Actions의 `SOPS 비밀값 최초 변환` 워크플로우를 수동 실행합니다. 이 작업은 기존 `ENV_VARS`를 암호화된 파일로 한 번만 옮깁니다. 변환과 배포 확인 뒤에는 `ENV_VARS`를 삭제해도 됩니다.
+#### 최초 1회 전환
 
-이후 환경변수를 추가·수정할 때는 SOPS로 `k8s/dup-env.sops.yaml`을 열어 변경하고 커밋합니다. 실제 값은 암호화되어 GitHub에 저장됩니다.
+1. `age`로 만든 `age.key` 파일을 안전한 비밀번호 관리자에 백업한다. 이 파일을 잃으면 암호화된 운영 비밀값을 열 수 없다.
+2. GitHub 저장소의 **Settings → Environments → Production → Secrets**에 `SOPS_AGE_KEY`를 만든다. 값은 `age.key` 파일의 전체 내용이다.
+
+   ```powershell
+   Get-Content -Raw age.key | gh secret set SOPS_AGE_KEY --env Production
+   ```
+
+3. `SOPS 비밀값 최초 변환` GitHub Actions 워크플로우를 수동 실행한다. 이 워크플로우는 기존 `ENV_VARS`를 읽어 `k8s/dup-env.sops.yaml`로 암호화해 커밋한다.
+4. `Deploy to Kubernetes` 워크플로우를 수동 실행한다. 이때 암호화 파일을 복호화해 K3s의 `dup-env` Secret으로 적용한다.
+5. 서비스가 정상 동작하는 것을 확인한 뒤에만 기존 GitHub `ENV_VARS` 시크릿을 삭제한다.
+
+`ENV_VARS`는 암호화 파일이 만들어지기 전 첫 배포를 위한 호환용이다. 전환이 끝난 뒤에는 새 환경변수를 추가할 때 GitHub 시크릿을 수정하지 않는다.
+
+#### 평소 환경변수 추가·수정
+
+1. SOPS를 한 번만 설치한다.
+
+   ```powershell
+   winget install -e --id Mozilla.SOPS
+   ```
+
+2. 현재 PowerShell에 복호화 키 파일 위치를 알려준다.
+
+   ```powershell
+   $env:SOPS_AGE_KEY_FILE = (Resolve-Path .\age.key)
+   ```
+
+3. 암호화된 운영 설정을 연다.
+
+   ```powershell
+   sops k8s/dup-env.sops.yaml
+   ```
+
+4. `stringData` 아래에 값을 추가하거나 수정한 뒤 저장하고 편집기를 닫는다. 예를 들어 노션·텔레그램 연동을 켤 때는 다음처럼 추가한다.
+
+   ```yaml
+   stringData:
+     NOTION_API_TOKEN: 실제-노션-토큰
+     NOTION_PAYMENT_DATABASE_ID: 실제-데이터베이스-ID
+     FRONTEND_BASE_URL: https://arc.baeksung.kr
+     TELEGRAM_BOT_TOKEN: 실제-텔레그램-봇-토큰
+     TELEGRAM_CHAT_ID: 실제-채팅방-ID
+   ```
+
+5. 암호화된 파일만 커밋하고 `main`에 병합한다. 배포 워크플로우가 자동으로 K3s Secret과 DUP Pod를 갱신한다.
+
+   ```powershell
+   git add k8s/dup-env.sops.yaml
+   git commit -m "운영 환경변수 수정"
+   git push
+   ```
+
+#### 꼭 지킬 것
+
+- `age.key`와 `AGE-SECRET-KEY-1...` 값은 Git, 채팅, 문서에 올리지 않는다.
+- `k8s/dup-env.sops.yaml`은 Git에 올려도 되지만, `k8s/dup-env.yaml` 같은 복호화된 파일은 올리면 안 된다.
+- `.gitignore`가 `age.key`와 복호화된 파일을 제외한다. 그래도 `git status`로 커밋 전 확인한다.
+- 새 설정값은 가능하면 기본값을 둬서, 기능을 켜기 전까지 배포가 실패하지 않게 만든다.
+
+실제 값은 암호화되어 GitHub에 저장되며, `age.key` 또는 GitHub의 `SOPS_AGE_KEY` 없이는 읽을 수 없다.
 
 ## 로컬 개발 환경 설정
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ PAYMENT_SUMMARY_MINUTE=30
 
 연동은 DUP에서 노션으로만 데이터를 보냅니다. 금액, 설명, 계좌번호, 요청·증빙 첨부파일은 노션과 텔레그램으로 전송하지 않습니다.
 
+### 운영 환경 비밀값 관리
+
+운영 비밀값은 `.env` 파일을 Docker 이미지에 포함하지 않고, 암호화된 `k8s/dup-env.sops.yaml` 파일에서 Kubernetes Secret으로 배포합니다.
+
+최초 1회에는 GitHub `Production` 환경 시크릿에 `SOPS_AGE_KEY`를 등록한 뒤, Actions의 `SOPS 비밀값 최초 변환` 워크플로우를 수동 실행합니다. 이 작업은 기존 `ENV_VARS`를 암호화된 파일로 한 번만 옮깁니다. 변환과 배포 확인 뒤에는 `ENV_VARS`를 삭제해도 됩니다.
+
+이후 환경변수를 추가·수정할 때는 SOPS로 `k8s/dup-env.sops.yaml`을 열어 변경하고 커밋합니다. 실제 값은 암호화되어 GitHub에 저장됩니다.
+
 ## 로컬 개발 환경 설정
 
 ### 1. uv 설치

--- a/README.md
+++ b/README.md
@@ -80,7 +80,31 @@ REDIS_HOST=your_redis_host
 REDIS_PORT=your_redis_port
 REDIS_PASSWORD=your_redis_password
 SLACK_WEBHOOK_URL=your_slack_webhook_url
+# 납부 업무 외부 연동 (설정하지 않으면 연동은 비활성화됩니다)
+NOTION_API_TOKEN=your_notion_integration_token
+NOTION_PAYMENT_DATABASE_ID=your_notion_database_id
+FRONTEND_BASE_URL=https://arc.baeksung.kr
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token
+TELEGRAM_CHAT_ID=your_telegram_chat_id
+PAYMENT_SUMMARY_HOUR=8
+PAYMENT_SUMMARY_MINUTE=30
 ```
+
+### 납부 업무 노션 데이터베이스
+
+노션에서 `DUP 납부 일정` 데이터베이스를 만들고, 해당 데이터베이스를 연동에 공유해야 합니다. 속성 이름과 종류는 아래처럼 정확히 맞춰야 합니다.
+
+| 속성 | 종류 |
+| --- | --- |
+| 업무명 | 제목 |
+| 납부일 | 날짜 |
+| 상태 | 선택 (`기한 미설정`, `납부 대기`, `기한 초과`, `완료`) |
+| 담당자 | 텍스트 |
+| DUP에서 확인 | URL |
+| DUP 업무 ID | 텍스트 |
+| 마지막 동기화 | 날짜 |
+
+연동은 DUP에서 노션으로만 데이터를 보냅니다. 금액, 설명, 계좌번호, 요청·증빙 첨부파일은 노션과 텔레그램으로 전송하지 않습니다.
 
 ## 로컬 개발 환경 설정
 

--- a/application/payment_task_notification_service.py
+++ b/application/payment_task_notification_service.py
@@ -1,0 +1,132 @@
+"""Notion calendar sync and Telegram summaries for payment tasks.
+
+Only non-sensitive task data leaves DUP.  A missing integration setting makes
+these methods harmless so local development and payment saving keep working.
+"""
+
+from datetime import date, datetime
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+from pytz import timezone
+
+from domain.payment_task import PaymentTask
+from domain.repository.payment_task_repo import IPaymentTaskRepository
+from utils.settings import settings
+
+
+class PaymentTaskNotificationService:
+    notion_version = "2022-06-28"
+    notion_base_url = "https://api.notion.com/v1"
+
+    def __init__(self, payment_task_repo: IPaymentTaskRepository):
+        self.payment_task_repo = payment_task_repo
+
+    @property
+    def notion_enabled(self) -> bool:
+        return bool(settings.notion_api_token and settings.notion_payment_database_id)
+
+    async def sync_task(self, task: PaymentTask) -> None:
+        """Create or update one Notion page, keyed by DUP task ID."""
+        if not self.notion_enabled:
+            return
+
+        headers = {
+            "Authorization": f"Bearer {settings.notion_api_token}",
+            "Notion-Version": self.notion_version,
+            "Content-Type": "application/json",
+        }
+        async with aiohttp.ClientSession(headers=headers) as session:
+            page_id = await self._find_page_id(session, task.id)
+            payload = {"properties": self._notion_properties(task)}
+            if page_id:
+                async with session.patch(f"{self.notion_base_url}/pages/{page_id}", json=payload) as response:
+                    await self._raise_for_error(response, "노션 일정 수정")
+            else:
+                payload["parent"] = {"database_id": settings.notion_payment_database_id}
+                async with session.post(f"{self.notion_base_url}/pages", json=payload) as response:
+                    await self._raise_for_error(response, "노션 일정 생성")
+        task.notion_sync_needed = False
+        await self.payment_task_repo.update(task)
+
+    async def retry_unsynced_tasks(self) -> None:
+        """A retry is idempotent because sync_task always searches by DUP ID."""
+        if not self.notion_enabled:
+            return
+        for task in await self.payment_task_repo.find_for_notion_sync():
+            try:
+                await self.sync_task(task)
+            except Exception as error:
+                # One failed page must not prevent the next payment task retry.
+                print(f"납부 업무 노션 동기화 재시도 실패 ({task.id}): {error}")
+
+    async def refresh_active_task_statuses(self) -> None:
+        """At midnight, reflect newly overdue tasks in the Notion status."""
+        if not self.notion_enabled:
+            return
+        for task in await self.payment_task_repo.find_active_for_notion_status():
+            try:
+                await self.sync_task(task)
+            except Exception as error:
+                task.notion_sync_needed = True
+                await self.payment_task_repo.update(task)
+                print(f"납부 업무 노션 상태 갱신 실패 ({task.id}): {error}")
+
+    async def send_daily_summary(self) -> None:
+        if not (settings.telegram_bot_token and settings.telegram_chat_id):
+            return
+        counts = await self.payment_task_repo.get_daily_summary(self._today())
+        message = (
+            "🔔 DUP 납부 요약\n\n"
+            f"오늘 납부 {counts['today_count']}건\n"
+            f"기한 초과 {counts['overdue_count']}건\n"
+            f"기한 미설정 {counts['unset_count']}건\n\n"
+            "노션 캘린더를 확인해 주세요."
+        )
+        url = f"https://api.telegram.org/bot{settings.telegram_bot_token}/sendMessage"
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json={"chat_id": settings.telegram_chat_id, "text": message}) as response:
+                await self._raise_for_error(response, "텔레그램 납부 요약 발송")
+
+    async def _find_page_id(self, session: aiohttp.ClientSession, task_id: str) -> Optional[str]:
+        url = f"{self.notion_base_url}/databases/{settings.notion_payment_database_id}/query"
+        payload = {"filter": {"property": "DUP 업무 ID", "rich_text": {"equals": task_id}}}
+        async with session.post(url, json=payload) as response:
+            data = await self._json_or_error(response, "노션 일정 조회")
+        results = data.get("results", [])
+        return results[0]["id"] if results else None
+
+    def _notion_properties(self, task: PaymentTask) -> Dict[str, Any]:
+        due_date = {"date": {"start": task.due_date.isoformat()}} if task.due_date else {"date": None}
+        return {
+            "업무명": {"title": [{"text": {"content": f"[납부] {task.request_name or task.title}"}}]},
+            "납부일": due_date,
+            "상태": {"select": {"name": self._status_name(task)}},
+            "담당자": {"rich_text": [{"text": {"content": task.assignee_name}}]},
+            "DUP에서 확인": {"url": f"{settings.frontend_base_url.rstrip('/')}/approval/payment-tasks/{task.id}"},
+            "DUP 업무 ID": {"rich_text": [{"text": {"content": task.id}}]},
+            "마지막 동기화": {"date": {"start": datetime.now(timezone('Asia/Seoul')).isoformat()}},
+        }
+
+    @staticmethod
+    def _status_name(task: PaymentTask) -> str:
+        if task.status == "COMPLETED":
+            return "완료"
+        if not task.due_date:
+            return "기한 미설정"
+        return "기한 초과" if task.due_date < PaymentTaskNotificationService._today() else "납부 대기"
+
+    @staticmethod
+    def _today() -> date:
+        return datetime.now(timezone("Asia/Seoul")).date()
+
+    @staticmethod
+    async def _json_or_error(response: aiohttp.ClientResponse, action: str) -> Dict[str, Any]:
+        if response.status < 400:
+            return await response.json()
+        body = await response.text()
+        raise RuntimeError(f"{action} 실패 ({response.status}): {body[:500]}")
+
+    @classmethod
+    async def _raise_for_error(cls, response: aiohttp.ClientResponse, action: str) -> None:
+        await cls._json_or_error(response, action)

--- a/application/payment_task_service.py
+++ b/application/payment_task_service.py
@@ -8,6 +8,7 @@ from ulid import ULID
 from application.approval_notification_service import ApprovalNotificationService
 from application.base_service import BaseService
 from application.file_attachment_service import FileAttachmentService
+from application.payment_task_notification_service import PaymentTaskNotificationService
 from common.auth import Role
 from domain.payment_task import PaymentTask
 from domain.repository.payment_task_repo import IPaymentTaskRepository
@@ -25,11 +26,13 @@ class PaymentTaskService(BaseService[PaymentTask]):
         user_repo: IUserRepository,
         file_service: FileAttachmentService,
         notification_service: ApprovalNotificationService,
+        payment_task_notification_service: PaymentTaskNotificationService,
     ):
         super().__init__(user_repo)
         self.payment_task_repo = payment_task_repo
         self.file_service = file_service
         self.notification_service = notification_service
+        self.payment_task_notification_service = payment_task_notification_service
         self.ulid = ULID()
 
     async def create_direct_payment_task(
@@ -60,6 +63,7 @@ class PaymentTaskService(BaseService[PaymentTask]):
         task = await self.payment_task_repo.save(task)
         await self._add_request_files(task, files, requester_id)
         await self.notification_service.notify_payment_task_assigned(task)
+        await self._sync_to_notion(task)
         return self.serialize_task(task)
 
     async def get_my_tasks(self, user_id: str, status: Optional[str] = None, limit: int = 100) -> List[Dict[str, Any]]:
@@ -68,6 +72,11 @@ class PaymentTaskService(BaseService[PaymentTask]):
 
     async def get_my_summary(self, user_id: str) -> Dict[str, int]:
         return await self.payment_task_repo.get_assignee_summary(user_id)
+
+    async def get_task(self, task_id: str, user_id: str, user_roles: List[Role]) -> Dict[str, Any]:
+        task = await self._get_task(task_id)
+        self._validate_task_access(task, user_id, user_roles)
+        return self.serialize_task(task)
 
     async def confirm_direct_request(self, task_id: str, user_id: str) -> Dict[str, Any]:
         task = await self._get_task(task_id)
@@ -81,6 +90,7 @@ class PaymentTaskService(BaseService[PaymentTask]):
             task.confirmed_by = user_id
             task.updated_at = task.confirmed_at
             task = await self.payment_task_repo.update(task)
+            await self._sync_to_notion(task)
         return self.serialize_task(task)
 
     async def update_direct_request(self, task_id: str, requester_id: str, data: Dict[str, Any], files: List[UploadFile], deleted_file_ids: List[str]) -> Dict[str, Any]:
@@ -98,6 +108,7 @@ class PaymentTaskService(BaseService[PaymentTask]):
         await self._add_request_files(task, files, requester_id, save=False)
         task.updated_at = get_utc_now_naive()
         task = await self.payment_task_repo.update(task)
+        await self._sync_to_notion(task)
         return self.serialize_task(task)
 
     async def set_due_date(self, task_id: str, user_id: str, due_date: str) -> Dict[str, Any]:
@@ -110,7 +121,9 @@ class PaymentTaskService(BaseService[PaymentTask]):
         task.status = "PENDING_PAYMENT"
         task.title = self.build_title(task.request_name, task.due_date)
         task.updated_at = get_utc_now_naive()
-        return self.serialize_task(await self.payment_task_repo.update(task))
+        task = await self.payment_task_repo.update(task)
+        await self._sync_to_notion(task)
+        return self.serialize_task(task)
 
     async def get_task_files(self, task_id: str, user_id: str, user_roles: List[Role]):
         task = await self._get_task(task_id)
@@ -142,7 +155,9 @@ class PaymentTaskService(BaseService[PaymentTask]):
         task.receipt_file_ids = receipt_ids
         task.completed_at = get_utc_now_naive()
         task.updated_at = task.completed_at
-        return self.serialize_task(await self.payment_task_repo.update(task))
+        task = await self.payment_task_repo.update(task)
+        await self._sync_to_notion(task)
+        return self.serialize_task(task)
 
     async def update_completion(
         self,
@@ -181,13 +196,24 @@ class PaymentTaskService(BaseService[PaymentTask]):
                 task.receipt_file_ids.append(attached_file.id)
 
         task.updated_at = get_utc_now_naive()
-        return self.serialize_task(await self.payment_task_repo.update(task))
+        task = await self.payment_task_repo.update(task)
+        await self._sync_to_notion(task)
+        return self.serialize_task(task)
 
     async def _get_task(self, task_id: str) -> PaymentTask:
         task = await self.payment_task_repo.find_by_id(task_id)
         if not task:
             raise HTTPException(status_code=404, detail="납부 업무를 찾을 수 없습니다.")
         return task
+
+    async def _sync_to_notion(self, task: PaymentTask) -> None:
+        task.notion_sync_needed = True
+        await self.payment_task_repo.update(task)
+        try:
+            await self.payment_task_notification_service.sync_task(task)
+        except Exception as error:
+            # 외부 일정 장애 때문에 납부 업무 저장을 실패시키지 않는다.
+            print(f"납부 업무 노션 동기화 실패 ({task.id}): {error}")
 
     async def _add_request_files(self, task: PaymentTask, files: List[UploadFile], uploaded_by: str, save: bool = True) -> None:
         for file in files:

--- a/containers.py
+++ b/containers.py
@@ -14,6 +14,7 @@ from application.file_attachment_service import FileAttachmentService
 from application.integrity_service import IntegrityService
 from application.legal_archive_service import LegalArchiveService
 from application.payment_task_service import PaymentTaskService
+from application.payment_task_notification_service import PaymentTaskNotificationService
 from infra.repository.file_repo import FileRepository
 from infra.repository.user_repo import UserRepository
 from infra.repository.voucher_repo import VoucherRepository
@@ -86,6 +87,10 @@ class Container(containers.DeclarativeContainer):
     attached_file_repo = providers.Factory(AttachedFileRepository)
     document_integrity_repo = providers.Factory(DocumentIntegrityRepository)
     payment_task_repo = providers.Factory(PaymentTaskRepository)
+    payment_task_notification_service = providers.Factory(
+        PaymentTaskNotificationService,
+        payment_task_repo=payment_task_repo,
+    )
     
     # 전자결재 시스템 서비스
     document_template_service = providers.Factory(
@@ -156,6 +161,7 @@ class Container(containers.DeclarativeContainer):
         user_repo=user_repo,
         file_service=file_attachment_service,
         notification_service=approval_notification_service,
+        payment_task_notification_service=payment_task_notification_service,
     )
 
     approval_service = providers.Factory(

--- a/domain/payment_task.py
+++ b/domain/payment_task.py
@@ -30,6 +30,7 @@ class PaymentTask(BaseResponse):
     completion_note: str = ""
     request_file_ids: List[str] = Field(default_factory=list)
     receipt_file_ids: List[str] = Field(default_factory=list)
+    notion_sync_needed: bool = True
     created_at: datetime
     updated_at: datetime
 

--- a/domain/repository/payment_task_repo.py
+++ b/domain/repository/payment_task_repo.py
@@ -33,3 +33,15 @@ class IPaymentTaskRepository(metaclass=ABCMeta):
     @abstractmethod
     async def get_assignee_summary(self, assignee_id: str) -> dict:
         raise NotImplementedError
+
+    @abstractmethod
+    async def find_for_notion_sync(self) -> List[PaymentTask]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_daily_summary(self, today) -> dict:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def find_active_for_notion_status(self) -> List[PaymentTask]:
+        raise NotImplementedError

--- a/infra/db_models/payment_task.py
+++ b/infra/db_models/payment_task.py
@@ -30,6 +30,7 @@ class PaymentTask(Document):
     completion_note: str = ""
     request_file_ids: List[str] = Field(default_factory=list)
     receipt_file_ids: List[str] = Field(default_factory=list)
+    notion_sync_needed: bool = True
     created_at: datetime
     updated_at: datetime
 

--- a/infra/repository/payment_task_repo.py
+++ b/infra/repository/payment_task_repo.py
@@ -38,3 +38,26 @@ class PaymentTaskRepository(BaseRepository[PaymentTask], IPaymentTaskRepository)
             {**active_query, "is_request_confirmed": False}
         ).count()
         return {"today_count": today_count, "confirmation_count": confirmation_count}
+
+    async def find_for_notion_sync(self) -> List[PaymentTask]:
+        query = {
+            "$or": [
+                {"notion_sync_needed": True},
+                {"notion_sync_needed": {"$exists": False}, "status": {"$ne": "COMPLETED"}},
+            ]
+        }
+        return await PaymentTask.find(query).sort(PaymentTask.updated_at).to_list()
+
+    async def get_daily_summary(self, today: date) -> dict:
+        active_query = {"status": {"$ne": "COMPLETED"}}
+        today_count = await PaymentTask.find({**active_query, "due_date": today}).count()
+        overdue_count = await PaymentTask.find({**active_query, "due_date": {"$lt": today}}).count()
+        unset_count = await PaymentTask.find({**active_query, "due_date": None}).count()
+        return {
+            "today_count": today_count,
+            "overdue_count": overdue_count,
+            "unset_count": unset_count,
+        }
+
+    async def find_active_for_notion_status(self) -> List[PaymentTask]:
+        return await PaymentTask.find({"status": {"$ne": "COMPLETED"}}).to_list()

--- a/interface/controller/payment_task_controller.py
+++ b/interface/controller/payment_task_controller.py
@@ -67,6 +67,17 @@ async def get_my_payment_task_summary(
     return await payment_task_service.get_my_summary(current_user.id)
 
 
+@router.get("/{task_id}")
+@inject
+async def get_payment_task(
+    task_id: str,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    payment_task_service: PaymentTaskService = Depends(Provide[Container.payment_task_service]),
+):
+    """요청자·담당자·관리자만 딥링크로 납부 업무를 조회한다."""
+    return await payment_task_service.get_task(task_id, current_user.id, current_user.roles)
+
+
 @router.patch("/{task_id}/due-date")
 @inject
 async def set_payment_task_due_date(

--- a/utils/scheduler.py
+++ b/utils/scheduler.py
@@ -12,6 +12,7 @@ scheduler = AsyncIOScheduler(timezone="Asia/Seoul")
 
 container = Container()
 voucher_service = container.voucher_service()  # DI로 받은 서비스 인스턴스
+payment_task_notification_service = container.payment_task_notification_service()
 
 
 async def crawl_and_save_job():
@@ -50,6 +51,21 @@ async def crawl_and_save_job():
         await send_slack_message(f"✅ 전표 스케줄 작업 완료 ({total_voucher_count}건)")
 
 
+async def retry_payment_task_notion_sync_job():
+    await payment_task_notification_service.retry_unsynced_tasks()
+
+
+async def send_payment_task_summary_job():
+    try:
+        await payment_task_notification_service.send_daily_summary()
+    except Exception as error:
+        print(f"텔레그램 납부 요약 발송 실패: {error}")
+
+
+async def refresh_payment_task_notion_status_job():
+    await payment_task_notification_service.refresh_active_task_statuses()
+
+
 def start_scheduler():
     # 매일 오전 8시에 실행
     scheduler.add_job(
@@ -57,6 +73,32 @@ def start_scheduler():
         CronTrigger(hour=12, minute=0, timezone=timezone("Asia/Seoul")),
         id='whg_crawl_8am',
         replace_existing=True
+    )
+
+    # 실패한 노션 동기화와 배포 전 미완료 업무를 10분마다 안전하게 재시도한다.
+    scheduler.add_job(
+        retry_payment_task_notion_sync_job,
+        "interval",
+        minutes=10,
+        id="payment_task_notion_retry",
+        replace_existing=True,
+        next_run_time=datetime.datetime.now(timezone("Asia/Seoul")),
+    )
+    scheduler.add_job(
+        refresh_payment_task_notion_status_job,
+        CronTrigger(hour=0, minute=5, timezone=timezone("Asia/Seoul")),
+        id="payment_task_notion_daily_status",
+        replace_existing=True,
+    )
+    scheduler.add_job(
+        send_payment_task_summary_job,
+        CronTrigger(
+            hour=settings.payment_summary_hour,
+            minute=settings.payment_summary_minute,
+            timezone=timezone("Asia/Seoul"),
+        ),
+        id="payment_task_telegram_summary",
+        replace_existing=True,
     )
     
     # 매일 저녁 6시에 실행

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -1,5 +1,6 @@
 # settings.py
 from pydantic_settings import BaseSettings
+from typing import Optional
 
 class Settings(BaseSettings):
     wehago_id: str
@@ -10,6 +11,13 @@ class Settings(BaseSettings):
     redis_port: int
     redis_password: str
     slack_webhook_url: str
+    notion_api_token: Optional[str] = None
+    notion_payment_database_id: Optional[str] = None
+    frontend_base_url: str = "https://arc.baeksung.kr"
+    telegram_bot_token: Optional[str] = None
+    telegram_chat_id: Optional[str] = None
+    payment_summary_hour: int = 8
+    payment_summary_minute: int = 30
 
     class Config:
         env_file = ".env"  # .env 파일을 사용하도록 지정


### PR DESCRIPTION
## 변경 내용

- 딥링크용 납부 업무 단건 조회 API와 권한 검사를 추가했습니다.
- DUP에서 노션으로 한 방향으로 동기화하고, 중복 생성 방지·실패 재시도·미완료 업무 최초 이관을 추가했습니다.
- 한국 시간 기준 텔레그램 납부 요약과 노션 기한 초과 상태 갱신 일정을 추가했습니다.
- 운영 비밀값을 SOPS + age로 암호화해 Kubernetes Secret으로 주입하는 배포 흐름을 추가했습니다.
- 필요한 환경 변수와 노션 데이터베이스 속성을 문서화했습니다.

## 변경 이유

DUP를 납부 업무의 기준 데이터로 유지하면서, 노션은 캘린더 화면으로, 텔레그램은 민감한 정보 없는 건수 알림으로 사용하기 위함입니다. 또한 `.env`가 Docker 이미지에 포함되지 않도록 바꿨습니다.

## 확인

- 변경한 백엔드 모듈 문법 검사 성공
- 의존성 주입 생성 확인 성공
- FastAPI 단건 조회 경로 등록 확인 성공
- 배포 워크플로우 공백 오류 검사 성공
