### PR TITLE
SOPS 설치 작업 수정

### DIFF
--- a/.github/actions/setup-sops/action.yml
+++ b/.github/actions/setup-sops/action.yml
@@ -1,0 +1,18 @@
+name: SOPS 설치
+description: 고정된 공식 릴리스 바이너리로 SOPS를 설치합니다.
+
+runs:
+  using: composite
+  steps:
+    - name: SOPS 다운로드
+      shell: bash
+      run: |
+        SOPS_VERSION="3.10.2"
+        SOPS_DIRECTORY="$RUNNER_TEMP/sops"
+        mkdir -p "$SOPS_DIRECTORY"
+        curl --fail --location --retry 3 \
+          "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" \
+          --output "$SOPS_DIRECTORY/sops"
+        chmod 755 "$SOPS_DIRECTORY/sops"
+        "$SOPS_DIRECTORY/sops" --version
+        echo "$SOPS_DIRECTORY" >> "$GITHUB_PATH"

--- a/.github/workflows/bootstrap-sops-secret.yml
+++ b/.github/workflows/bootstrap-sops-secret.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: SOPS 설치
-        uses: getsops/action@v2
+        uses: ./.github/actions/setup-sops
 
       - name: 기존 ENV_VARS를 암호화된 Kubernetes Secret으로 변환
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       # SOPS 파일이 준비되기 전 첫 배포만 기존 ENV_VARS를 사용한다.
       # 변환이 끝나면 ENV_VARS를 삭제해도 된다.
       - name: SOPS 설치
-        uses: getsops/action@v2
+        uses: ./.github/actions/setup-sops
 
       - name: Kubernetes Secret 준비
         env:


### PR DESCRIPTION
## 변경 내용

- 존재하지 않는 `getsops/action` 참조를 제거했습니다.
- 저장소 안의 공통 SOPS 설치 작업을 추가했습니다.
- 고정된 공식 SOPS 릴리스 바이너리를 내려받아 두 배포 워크플로우에서 함께 사용합니다.

## 원인

기존 워크플로우가 존재하지 않는 GitHub Action을 호출해서 SOPS 설치 단계에서 실패했습니다.

## 확인

- 잘못된 Action 참조가 남아 있지 않은지 확인했습니다.
- 워크플로우 변경의 공백 오류를 확인했습니다.
