### PR TITLE
환경변수 Secret 변환 오류 수정

### DIFF
--- a/.github/workflows/bootstrap-sops-secret.yml
+++ b/.github/workflows/bootstrap-sops-secret.yml
@@ -22,29 +22,7 @@ jobs:
         env:
           ENV_VARS: ${{ secrets.ENV_VARS }}
         run: |
-          test -n "$ENV_VARS" || { echo "ENV_VARS 시크릿이 비어 있습니다."; exit 1; }
-          python3 - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          values = {}
-          for raw_line in os.environ["ENV_VARS"].splitlines():
-              line = raw_line.strip()
-              if not line or line.startswith("#"):
-                  continue
-              key, separator, value = raw_line.partition("=")
-              if not separator or not key.strip():
-                  raise ValueError(f"올바르지 않은 환경변수 줄입니다: {raw_line!r}")
-              values[key.strip()] = value
-
-          secret_file = Path("k8s/dup-env.sops.yaml")
-          secret_file.parent.mkdir(exist_ok=True)
-          with secret_file.open("w", encoding="utf-8") as file:
-              file.write("apiVersion: v1\nkind: Secret\nmetadata:\n  name: dup-env\ntype: Opaque\nstringData:\n")
-              for key, value in sorted(values.items()):
-                  file.write(f"  {json.dumps(key, ensure_ascii=False)}: {json.dumps(value, ensure_ascii=False)}\n")
-          PY
+          python3 scripts/create_kubernetes_secret.py k8s/dup-env.sops.yaml
           sops --encrypt --in-place k8s/dup-env.sops.yaml
 
       - name: 암호화 파일 커밋

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,27 +29,7 @@ jobs:
             test -n "$SOPS_AGE_KEY" || { echo "SOPS_AGE_KEY 시크릿이 비어 있습니다."; exit 1; }
             sops --decrypt k8s/dup-env.sops.yaml > k8s/dup-env.yaml
           else
-            test -n "$ENV_VARS" || { echo "ENV_VARS 시크릿이 비어 있습니다."; exit 1; }
-            python3 - <<'PY'
-            import json
-            import os
-            from pathlib import Path
-
-            values = {}
-            for raw_line in os.environ["ENV_VARS"].splitlines():
-                line = raw_line.strip()
-                if not line or line.startswith("#"):
-                    continue
-                key, separator, value = raw_line.partition("=")
-                if not separator or not key.strip():
-                    raise ValueError(f"올바르지 않은 환경변수 줄입니다: {raw_line!r}")
-                values[key.strip()] = value
-
-            with Path("k8s/dup-env.yaml").open("w", encoding="utf-8") as file:
-                file.write("apiVersion: v1\nkind: Secret\nmetadata:\n  name: dup-env\ntype: Opaque\nstringData:\n")
-                for key, value in sorted(values.items()):
-                    file.write(f"  {json.dumps(key, ensure_ascii=False)}: {json.dumps(value, ensure_ascii=False)}\n")
-            PY
+            python3 scripts/create_kubernetes_secret.py k8s/dup-env.yaml
 
       - name: Kubernetes Secret 전달
         uses: appleboy/scp-action@master

--- a/scripts/create_kubernetes_secret.py
+++ b/scripts/create_kubernetes_secret.py
@@ -1,0 +1,40 @@
+"""Convert ENV_VARS into a Kubernetes Secret manifest without exposing values."""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def parse_env_vars(raw_value: str) -> dict[str, str]:
+    values = {}
+    for raw_line in raw_value.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, separator, value = raw_line.partition("=")
+        if not separator or not key.strip():
+            raise ValueError(f"올바르지 않은 환경변수 줄입니다: {raw_line!r}")
+        values[key.strip()] = value
+    return values
+
+
+def write_secret(output_path: Path, values: dict[str, str]) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as file:
+        file.write("apiVersion: v1\nkind: Secret\nmetadata:\n  name: dup-env\ntype: Opaque\nstringData:\n")
+        for key, value in sorted(values.items()):
+            file.write(f"  {json.dumps(key, ensure_ascii=False)}: {json.dumps(value, ensure_ascii=False)}\n")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("사용법: python3 scripts/create_kubernetes_secret.py <출력-파일>")
+    raw_value = os.environ.get("ENV_VARS", "")
+    if not raw_value:
+        raise SystemExit("ENV_VARS 시크릿이 비어 있습니다.")
+    write_secret(Path(sys.argv[1]), parse_env_vars(raw_value))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 변경 내용

- 워크플로우 안의 여러 줄 Python 코드를 공통 스크립트로 옮겼습니다.
- 기존 `ENV_VARS`를 Kubernetes Secret YAML로 바꾸는 로직을 한 곳에서 재사용합니다.
- 잘못된 here-document 끝 표시 때문에 배포가 멈추던 오류를 제거했습니다.

## 원인

GitHub Actions YAML의 들여쓰기로 Python 코드 끝 표시가 쉘에서 인식되지 않아, 스크립트가 끝나기 전에 실패했습니다.

## 확인

- 환경변수 예시 값을 Secret 데이터로 변환하는 단위 확인 성공
- Python 문법 검사 성공
- 워크플로우 공백 오류 검사 성공
