### PR TITLE
업무파일 정렬과 전체 동기화 개선

### DIFF
--- a/application/file_service.py
+++ b/application/file_service.py
@@ -82,7 +82,7 @@ class FileService(BaseService[File]):
         type: Optional[Type] = Type.VOUCHER,
         start_at: Optional[str] = None,
         end_at: Optional[str] = None,
-        sort_by: str = "created_at",
+        sort_by: str = "withdrawn_at",
         order: str = "desc",
         page: int = 1,
         items_per_page: int = 30,

--- a/application/voucher_service.py
+++ b/application/voucher_service.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 from typing import Optional
 import zipfile
+import asyncio
 
 from beanie.operators import And, RegEx, In
 from dependency_injector.wiring import inject
@@ -31,8 +32,29 @@ class VoucherService:
         wehago_id: str = None,
         wehago_password: str = None,
     ):
-        # 🚀 async 크롤링 직접 실행 (병렬 처리)
         vouchers = await Whg().crawl_whg(company, year, month, wehago_id, wehago_password)
+        return await self._save_synced_vouchers(company, year, month, vouchers)
+
+    async def sync_many(
+        self,
+        companies: list[Company],
+        year: int,
+        month: int = None,
+        wehago_id: str = None,
+        wehago_password: str = None,
+    ) -> dict[Company, list]:
+        vouchers_by_company = await Whg().crawl_companies(
+            companies, year, month, wehago_id, wehago_password
+        )
+        synced_vouchers = await asyncio.gather(
+            *(
+                self._save_synced_vouchers(company, year, month, vouchers)
+                for company, vouchers in vouchers_by_company.items()
+            )
+        )
+        return dict(zip(vouchers_by_company, synced_vouchers))
+
+    async def _save_synced_vouchers(self, company: Company, year: int, month: int, vouchers: list):
 
         # 3. 새로 수집한 ID 목록
         new_ids = {v.id for v in vouchers}

--- a/domain/repository/file_repo.py
+++ b/domain/repository/file_repo.py
@@ -18,7 +18,7 @@ class IFileRepository(metaclass=ABCMeta):
     async def find_many(
         self,
         *filters: Any,
-        sort_by: str = "created_at",
+        sort_by: str = "withdrawn_at",
         order: str = "desc",
         page: int,
         items_per_page: int

--- a/infra/db_models/file.py
+++ b/infra/db_models/file.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from beanie import Document, PydanticObjectId
+from pymongo import ASCENDING, DESCENDING, IndexModel
 from pydantic import ConfigDict, Field
 from typing import Optional
 
@@ -29,6 +30,13 @@ class File(Document):
             "company",
             "type",
             "group_id",
+            IndexModel([
+                ("company", ASCENDING),
+                ("type", ASCENDING),
+                ("group_id", ASCENDING),
+                ("withdrawn_at", DESCENDING),
+                ("created_at", DESCENDING),
+            ]),
         ]
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/infra/repository/file_repo.py
+++ b/infra/repository/file_repo.py
@@ -50,22 +50,24 @@ class FileRepository(BaseRepository[File], IFileRepository):
     async def find_many(
         self,
         *filters: Any,
-        sort_by: str = "created_at",
+        sort_by: str = "withdrawn_at",
         order: str = "desc",
         page: int = 1,
         items_per_page: int = 10,
     ) -> tuple[int, list[File]]:
         offset = (page - 1) * items_per_page
 
-        sort_field_name = SORT_FIELDS.get(sort_by, "created_at")
-        sort_field = f"-{sort_field_name}" if order == "desc" else sort_field_name
+        sort_field_name = SORT_FIELDS.get(sort_by, "withdrawn_at")
+        primary_sort = f"-{sort_field_name}" if order == "desc" else sort_field_name
+        # 날짜가 같으면 가장 나중에 생성한 파일을 먼저 보여준다.
+        sort_fields = [primary_sort, "-created_at"]
 
         if filters:
             total_count = await File.find(*filters).count()
 
             files = (
                 await File.find(*filters)
-                .sort(sort_field)
+                .sort(*sort_fields)
                 .skip(offset)
                 .limit(items_per_page)
                 .to_list()
@@ -79,7 +81,7 @@ class FileRepository(BaseRepository[File], IFileRepository):
 
         files = (
             await File.find()
-            .sort(sort_field)
+            .sort(*sort_fields)
             .skip(offset)
             .limit(items_per_page)
             .to_list()

--- a/interface/controller/file_controller.py
+++ b/interface/controller/file_controller.py
@@ -94,7 +94,7 @@ async def find_files(
     search_option: Optional[str] = None,
     start_at: Optional[str] = None,
     end_at: Optional[str] = None,
-    sort_by: str = Query("created_at", description="Sort field"),
+    sort_by: str = Query("withdrawn_at", description="Sort field"),
     order: str = Query("desc", description="Sort order (asc or desc)"),
     company: Optional[Company] = Company.BAEKSUNG,
     type: Optional[Type] = Type.VOUCHER,

--- a/interface/controller/whg_controller.py
+++ b/interface/controller/whg_controller.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Response
 from fastapi import File
 from fastapi import Form
 from fastapi import UploadFile
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from redis.asyncio import Redis
 
 from application.sync_service import SyncService
@@ -37,6 +37,7 @@ class SyncRequest(BaseModel):
     month: int = None
     year: int = datetime.now().year
     company: Company = Company.BAEKSUNG
+    companies: list[Company] = Field(default_factory=list)
 
 
 @router.post("/sync")
@@ -53,14 +54,24 @@ async def sync_whg(
     await redis.publish("sync_status_channel", json.dumps({"syncing": True}))
 
     try:
-        await voucher_service.sync(
-            company=sync_request.company,
-            year=sync_request.year,
-            month=sync_request.month,
-            wehago_id=sync_request.wehago_id,
-            wehago_password=sync_request.wehago_password,
-        )
-        return {"message": "Sync completed successfully"}
+        companies = sync_request.companies
+        if companies:
+            await voucher_service.sync_many(
+                companies=companies,
+                year=sync_request.year,
+                month=sync_request.month,
+                wehago_id=sync_request.wehago_id,
+                wehago_password=sync_request.wehago_password,
+            )
+        else:
+            await voucher_service.sync(
+                company=sync_request.company,
+                year=sync_request.year,
+                month=sync_request.month,
+                wehago_id=sync_request.wehago_id,
+                wehago_password=sync_request.wehago_password,
+            )
+        return {"message": "Sync completed successfully", "companies": companies or [sync_request.company]}
     except HTTPException:
         raise
     except Exception as e:

--- a/utils/whg.py
+++ b/utils/whg.py
@@ -1,6 +1,7 @@
 import gzip
 import io
 import json
+import asyncio
 from datetime import datetime
 
 from playwright.async_api import async_playwright, Page, Response, TimeoutError as PlaywrightTimeoutError
@@ -55,7 +56,15 @@ class Whg:
         return config["base_gisu"] - (config["base_year"] - year)
 
     async def crawl_whg(self, company: Company, year: int, month: int, wehago_id: str, wehago_password: str):
-        """Async Playwright를 사용한 메인 크롤링 메소드 (병렬 처리)"""
+        vouchers_by_company = await self.crawl_companies(
+            [company], year, month, wehago_id, wehago_password
+        )
+        return vouchers_by_company[company]
+
+    async def crawl_companies(
+        self, companies: list[Company], year: int, month: int, wehago_id: str, wehago_password: str
+    ) -> dict[Company, list[Voucher]]:
+        """한 번 로그인한 세션에서 회사별 탭을 병렬로 열어 전표를 수집한다."""
         async with async_playwright() as p:
             browser = await p.chromium.launch(
                 headless=True,
@@ -91,13 +100,25 @@ class Whg:
                 await main_page.locator(".snbnext").wait_for(state="visible", timeout=10000)
                 logger.info("메인 페이지 로그인 완료 확인됨")
                 
-                company_vouchers, company_enum = await self._extract_company_data_parallel(
-                    context, company, year, month
+                results = await asyncio.gather(
+                    *(self._extract_company_data_parallel(context, company, year, month) for company in companies),
+                    return_exceptions=True,
                 )
-                for voucher in company_vouchers:
-                    voucher.company = company_enum.value
+                failed_companies = [
+                    company.value
+                    for company, result in zip(companies, results)
+                    if isinstance(result, Exception)
+                ]
+                if failed_companies:
+                    raise CrawlingError(f"전표 수집 실패: {', '.join(failed_companies)}")
 
-                return company_vouchers
+                vouchers_by_company = {}
+                for company_vouchers, company_enum in results:
+                    for voucher in company_vouchers:
+                        voucher.company = company_enum.value
+                    vouchers_by_company[company_enum] = company_vouchers
+
+                return vouchers_by_company
 
             except (LoginError, CrawlingError):
                 raise
@@ -114,20 +135,19 @@ class Whg:
     
     async def _extract_company_data_parallel(self, context, company: Company, year: int, month: int):
         """각 회사별 데이터를 별도 탭에서 처리"""
+        page = await context.new_page()
         try:
-            # 새 탭 생성 (컨텍스트 공유로 세션 보장)
-            page = await context.new_page()
             await page.route("**/*.{png,jpg,jpeg,gif,svg,woff,woff2}", lambda route: route.abort())
             
             # 바로 전표 데이터 추출 (로그인은 이미 메인 탭에서 완료됨)
             vouchers = await self._extract_voucher_data(page, company, year, month)
-            
-            await page.close()
             return vouchers, company
             
         except Exception as e:
             logger.error(f"{company.value} 처리 중 오류: {e}")
-            raise e
+            raise
+        finally:
+            await page.close()
 
     async def _login(self, page: Page, wehago_id: str, wehago_password: str) -> bool:
         """Playwright를 사용한 로그인 처리"""


### PR DESCRIPTION
## 변경 내용

- 업무파일 API의 기본 정렬을 날짜 최신순으로 변경했습니다.
- 같은 날짜의 업무파일을 생성 시각 최신순으로 정렬하고 조회 인덱스를 추가했습니다.
- 전체 전표 동기화는 로그인 한 번 뒤 회사별 탭을 병렬로 수집하도록 구현했습니다.

## 원인과 영향

날짜 동률의 순서가 일정하지 않고, 전체 동기화가 회사별 순차 처리라 느릴 수 있던 문제를 해결했습니다. 한 회사의 수집이 실패하면 저장을 시작하지 않습니다.

## 검증

- 백엔드 문법 검사 통과
- 변경사항 형식 검사 통과