### PR TITLE
업무파일 업로드 MIME 타입 확대

### DIFF
--- a/interface/controller/file_controller.py
+++ b/interface/controller/file_controller.py
@@ -31,10 +31,18 @@ router = APIRouter(prefix="/files", tags=["files"])
 
 ALLOWED_CONTENT_TYPES = {
     "application/pdf",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     "image/jpeg",
     "image/png",
+    "image/gif",
     "application/vnd.ms-excel",
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+    "application/haansoftxlsx",
+    "application/vnd.ms-powerpoint",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "text/plain",
     "application/x-hwp",
     "application/vnd.hancom.hwp",
     "application/haansofthwp",

--- a/interface/controller/file_controller.py
+++ b/interface/controller/file_controller.py
@@ -38,7 +38,6 @@ ALLOWED_CONTENT_TYPES = {
     "image/gif",
     "application/vnd.ms-excel",
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
     "application/haansoftxlsx",
     "application/vnd.ms-powerpoint",
     "application/vnd.openxmlformats-officedocument.presentationml.presentation",


### PR DESCRIPTION
## 변경 사항

- 업무파일 API의 MIME 허용 목록에 Word, PowerPoint, XLSB, GIF, TXT를 추가했습니다.
- 한컴에서 만든 XLSX의 `application/haansoftxlsx` MIME 타입도 허용합니다.

## 이유

파일 확장자는 업무용 문서지만 프로그램에 따라 MIME 타입 이름이 달라 업로드 검증에서 차단될 수 있었습니다.

## 영향

프런트에서 선택 가능한 업무 문서가 서버 검증에서도 정상 업로드됩니다. ZIP/RAR은 허용하지 않습니다.

## 검증

- Python 문법 검사 통과
- MIME 허용 목록 검사 통과